### PR TITLE
[CENTOS-13] Added packer build confiugration to create AWS AMI with GPU support for G3 AWS instances

### DIFF
--- a/centos7/centos7-gpu-g3-ami.json
+++ b/centos7/centos7-gpu-g3-ami.json
@@ -1,0 +1,68 @@
+{
+  "variables": {
+    "ssh_username": "centos",
+    "aws_instance_type": "g3.4xlarge",
+    "aws_profile": "{{env `AWS_PROFILE`}}",
+    "aws_region": "us-east-1",
+    "source_ami": "ami-02eac2c0129f6376b",
+    "aws_ami_prefix": "dart-centos7"
+  },
+  "builders": [
+    {
+      "profile": "{{user `aws_profile`}}",
+      "ami_name": "{{user `aws_ami_prefix`}}-gpu-g3-{{isotime | clean_resource_name}}",
+      "instance_type": "{{user `aws_instance_type`}}",
+      "region": "{{user `aws_region`}}",
+      "source_ami": "{{user `source_ami`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "type": "amazon-ebs",
+      "temporary_iam_instance_profile_policy_document": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Action": [
+              "s3:*"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+          }
+        ]
+      }
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "environment_vars": [
+        "SSH_USERNAME={{user `ssh_username`}}"
+      ],
+      "execute_command": "echo '{{user `ssh_password`}}' | sudo -E -S  env {{ .Vars }} bash '{{ .Path }}'",
+      "expect_disconnect": true,
+      "pause_before": "20s",
+      "scripts": [
+        "provision/setup.sh",
+        "private/setup.sh",
+        "provision/setup-gpu-requirements.sh"
+      ]
+    },
+    {
+      "type": "shell",
+      "inline": [
+        "sudo reboot"
+      ],
+      "inline_shebang": "/bin/bash -e",
+      "expect_disconnect": true
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "SSH_USERNAME={{user `ssh_username`}}"
+      ],
+      "execute_command": "echo '{{user `ssh_password`}}' | sudo -E -S  env {{ .Vars }} bash '{{ .Path }}'",
+      "pause_before": "30s",
+      "scripts": [
+        "provision/setup-gpu-drivers.sh"
+      ]
+    }
+  ]
+}

--- a/centos7/provision/setup-gpu-drivers.sh
+++ b/centos7/provision/setup-gpu-drivers.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+function install_gpu_drivers {
+
+  sudo yum update
+  sudo yum install -y gcc kernel-devel-$(uname -r)
+
+  aws s3 cp --recursive s3://ec2-linux-nvidia-drivers/latest/ .
+  chmod +x NVIDIA-Linux-x86_64*.run
+
+  sudo /bin/sh ./NVIDIA-Linux-x86_64*.run --ui=none -q -s
+
+  distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+
+  curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.repo | sudo tee /etc/yum.repos.d/nvidia-docker.repo
+  sudo yum install -y nvidia-container-toolkit
+  sudo systemctl restart docker
+
+}
+
+function test_gpu_installation {
+  sleep 10
+  nvidia-smi -q | head
+  docker run --gpus all nvidia/cuda:10.0-base nvidia-smi
+}
+
+install_gpu_drivers
+test_gpu_installation

--- a/centos7/provision/setup-gpu-requirements.sh
+++ b/centos7/provision/setup-gpu-requirements.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+function setup() {
+  sudo yum update -y
+
+  cat <<EOF | sudo tee --append /etc/modprobe.d/blacklist.conf
+blacklist vga16fb
+blacklist nouveau
+blacklist rivafb
+blacklist nvidiafb
+blacklist rivatv
+EOF
+
+  echo 'GRUB_CMDLINE_LINUX="rdblacklist=nouveau"' | sudo tee -a /etc/default/grub
+  sudo grub2-mkconfig -o /boot/grub2/grub.cfg
+}
+
+setup

--- a/centos7/provision/setup.sh
+++ b/centos7/provision/setup.sh
@@ -11,6 +11,7 @@ function setup {
     sudo yum install -y vim
     sudo yum install -y net-tools
     sudo yum install -y telnet
+    sudo yum install -y awscli
     sudo echo "vm.max_map_count = 262144" >> /etc/sysctl.conf
 
     ssh-keygen -b 4096 -t rsa -f $USER_HOME/.ssh/id_rsa -q -N "" -P "" -C michael.reynolds@twosixlabs.com
@@ -68,7 +69,9 @@ function install_docker {
     echo "installing docker"
     sudo groupadd docker
     sudo usermod -aG docker centos
-    sudo yum install -y docker
+    sudo yum-config-manager \
+          --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+    sudo yum -y install docker-ce docker-ce-cli containerd.io
     sudo /usr/local/bin/pip3 install docker-compose
     sudo mkdir $USER_HOME/etc
     sudo echo "#!/bin/bash" >> $USER_HOME/etc/docker-service.sh


### PR DESCRIPTION
The G3  build configuration requires latest packer version https://www.packer.io/downloads
I've also updated docker installation which installs latest version of docker 19.x